### PR TITLE
Cherry pick TLS support commits

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,5 +19,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0 # v1.0.2
         with:
-          go-version-input: 1.21.10
+          go-version-file: go.mod
           go-package: ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add TLS support for Trillian: By using `--trillian_tls_ca_cert_file` flag, users can provide a CA certificate, that is used to establish a secure communication with Trillian log server. In https://github.com/google/certificate-transparency-go/pull/1525
 
+* Add TLS support for ct_server: By using `--tls_certificate` and `--tls_key` flags, users can provide a service certificate and key, that enables the server to handle HTTPS requests. In https://github.com/google/certificate-transparency-go/pull/1523
+
 ## v1.2.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Add TLS support for Trillian: By using `--trillian_tls_ca_cert_file` flag, users can provide a CA certificate, that is used to establish a secure communication with Trillian log server. In https://github.com/google/certificate-transparency-go/pull/1525
+
 ## v1.2.1
 
 ### Fixes

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/certificate-transparency-go
 
-go 1.21.0
+go 1.21.12
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -57,6 +58,8 @@ import (
 // Global flags that affect all log instances.
 var (
 	httpEndpoint       = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port)")
+	tlsCert            = flag.String("tls_certificate", "", "Path to server TLS certificate")
+	tlsKey             = flag.String("tls_key", "", "Path to server TLS private key")
 	metricsEndpoint    = flag.String("metrics_endpoint", "", "Endpoint for serving metrics; if left empty, metrics will be visible on --http_endpoint")
 	rpcBackend         = flag.String("log_rpc_server", "", "Backend specification; comma-separated list or etcd service name (if --etcd_servers specified). If unset backends are specified in config (as a LogMultiConfig proto)")
 	rpcDeadline        = flag.Duration("rpc_deadline", time.Second*10, "Deadline for backend RPC requests")
@@ -306,7 +309,20 @@ func main() {
 	}
 
 	// Bring up the HTTP server and serve until we get a signal not to.
-	srv := http.Server{Addr: *httpEndpoint, Handler: handler}
+	srv := http.Server{}
+	if *tlsCert != "" && *tlsKey != "" {
+		cert, err := tls.LoadX509KeyPair(*tlsCert, *tlsKey)
+		if err != nil {
+			klog.Errorf("failed to load TLS certificate/key: %v", err)
+		}
+		tlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		}
+		srv = http.Server{Addr: *httpEndpoint, Handler: handler, TLSConfig: tlsConfig}
+	} else {
+		srv = http.Server{Addr: *httpEndpoint, Handler: handler}
+	}
 	shutdownWG := new(sync.WaitGroup)
 	go awaitSignal(func() {
 		shutdownWG.Add(1)


### PR DESCRIPTION
This PR cherry-pick 2 commits to enable TLS support for CTLog and Trillian log servers 
(+ 1 commit to fix tests)
https://github.com/google/certificate-transparency-go/pull/1523
https://github.com/google/certificate-transparency-go/pull/1525