### PR TITLE
fix: container RunAsNonRoot and /licenses

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -6,14 +6,13 @@ RUN CGO_ENABLED=0 go build -o ct_server -mod=readonly -trimpath ./trillian/ctfe/
 
 # Install server
 FROM registry.access.redhat.com/ubi9-minimal@sha256:4c8830d349732ed8066544e1cbcf878ad64f39aa4364f13cf4a69954b0ccbda5
+
+# Create a non-root user and group with a home directory
+RUN groupadd -r appgroup && \
+    useradd -r -g appgroup -d /home/appuser -m -s /sbin/nologin appuser
+
 COPY --from=build-env /ct_server/ct_server /usr/local/bin/ct_server
-RUN chown root:0 /usr/local/bin/ct_server && chmod g+wx /usr/local/bin/ct_server
-
-# Configure home directory
-ENV HOME=/home
-RUN chgrp -R 0 /${HOME} && chmod -R g=u /${HOME}
-
-WORKDIR ${HOME}
+COPY LICENSE /licenses/license.txt
 
 LABEL name="certifcate-transparency-server"
 LABEL description="The binary responsible for providing the Certificate Transparency (CT) log server."
@@ -22,6 +21,10 @@ LABEL io.k8s.display-name="CT server container image for Red Hat Trusted Artifac
 LABEL io.openshift.tags="CT-server, Red Hat trusted artifact signer."
 LABEL summary="Provides the CT-server binary."
 LABEL com.redhat.component="ct-server"
+
+USER appuser
+
+WORKDIR /home/appuser
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["ct_server"]


### PR DESCRIPTION
Fixes HasLicense
> Container images must contain a “licenses” directory. Use this directory to add files containing software terms and conditions for your product and any open source software included in the image.

Fixes RunAsNonRoot
> Container images must declare a non-root user unless their functionality requires privileged access.

https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images