### PR TITLE
feat(fips): bumping Go to 1.24

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -1,8 +1,12 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:98a0ff138c536eee98704d6909699ad5d0725a20573e2c510a60ef462b45cce0 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS build-env
+
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
+
 WORKDIR /ct_server
 RUN git config --global --add safe.directory /ct_server
 COPY . .
-RUN CGO_ENABLED=0 go build -o ct_server -mod=readonly -trimpath ./trillian/ctfe/ct_server
+RUN go build -o ct_server -mod=readonly -trimpath ./trillian/ctfe/ct_server
 
 # Install server
 FROM registry.access.redhat.com/ubi9-minimal@sha256:4fef3a1e53399e64f839190483711d361455bd18274954ce4bec4845575df83e


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.

## Summary by Sourcery

Build:
- Bump Go base image version to 1.24 in Dockerfile.rh