### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for certificate-transparency-go

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -18,7 +18,8 @@ RUN groupadd -r appgroup && \
 COPY --from=build-env /ct_server/ct_server /usr/local/bin/ct_server
 COPY LICENSE /licenses/license.txt
 
-LABEL name="certifcate-transparency-server"
+LABEL name="rhtas/certificate-transparency-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 LABEL description="The binary responsible for providing the Certificate Transparency (CT) log server."
 LABEL io.k8s.description="The binary responsible for providing the Certificate Transparency (CT) log server."
 LABEL io.k8s.display-name="CT server container image for Red Hat Trusted Artifact Signer."


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Build:
- Set the name and CPE labels in Dockerfile.rh to support Clair VEX integration