### PR TITLE
Removing cpe label

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -19,7 +19,6 @@ COPY --from=build-env /ct_server/ct_server /usr/local/bin/ct_server
 COPY LICENSE /licenses/license.txt
 
 LABEL name="rhtas/certificate-transparency-rhel9"
-LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 LABEL description="The binary responsible for providing the Certificate Transparency (CT) log server."
 LABEL io.k8s.description="The binary responsible for providing the Certificate Transparency (CT) log server."
 LABEL io.k8s.display-name="CT server container image for Red Hat Trusted Artifact Signer."


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Drop the "cpe" LABEL instruction from Dockerfile.rh