### PR TITLE
chore: Switch ed25519 import from deprecated x/crypto to stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [CTFE] Add a /log.v3.json endpoint to help satisfy a requirement of the Chrome CT Log Policy by @robstradling in https://github.com/google/certificate-transparency-go/pull/1703
 * [preloader] add continuous mode.
 * [CTFE] Enforce max request body size using `http.MaxBytesHandler`.
+* Switch Ed25519 import from deprecated `golang.org/x/crypto/ed25519` to stdlib `crypto/ed25519` by @JasonPowr 
 ## v1.3.2
 
 ### Misc

--- a/x509/example_test.go
+++ b/x509/example_test.go
@@ -7,12 +7,12 @@ package x509_test
 import (
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"encoding/pem"
 	"fmt"
 
 	"github.com/google/certificate-transparency-go/x509"
-	"golang.org/x/crypto/ed25519"
 )
 
 func ExampleCertificate_Verify() {

--- a/x509/pkcs8.go
+++ b/x509/pkcs8.go
@@ -6,15 +6,13 @@ package x509
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"errors"
 	"fmt"
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/x509/pkix"
-
-	// TODO(robpercival): change this to crypto/ed25519 when Go 1.13 is min version
-	"golang.org/x/crypto/ed25519"
 )
 
 // pkcs8 reflects an ASN.1, PKCS#8 PrivateKey. See

--- a/x509/pkcs8_test.go
+++ b/x509/pkcs8_test.go
@@ -7,15 +7,13 @@ package x509
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rsa"
 	"encoding/hex"
 	"reflect"
 	"strings"
 	"testing"
-
-	// TODO(robpercival): change this to crypto/ed25519 when Go 1.13 is min version
-	"golang.org/x/crypto/ed25519"
 )
 
 // Generated using:

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -52,6 +52,7 @@ import (
 	"crypto"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rsa"
 	_ "crypto/sha1"
@@ -71,7 +72,6 @@ import (
 
 	"golang.org/x/crypto/cryptobyte"
 	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
-	"golang.org/x/crypto/ed25519"
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/tls"

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/x509/pkix"
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestParsePKCS1PrivateKey(t *testing.T) {


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
