### PR TITLE
Update release-version to 1.3.6

### DIFF
--- a/.tekton/certificate-transparency-go-pull-request.yaml
+++ b/.tekton/certificate-transparency-go-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.5
+    value: 1.3.6
   - name: dockerfile
     value: Dockerfile.rh
   - name: git-url

--- a/.tekton/certificate-transparency-go-push.yaml
+++ b/.tekton/certificate-transparency-go-push.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.3.5
+    value: 1.3.6
   - name: dockerfile
     value: Dockerfile.rh
   - name: git-url


### PR DESCRIPTION
## Summary
Update the release-version parameter in Tekton pipeline definitions to 1.3.6 for the release-1.3 branch.

## Changes
- Updated release-version parameter from previous version to 1.3.6 in .tekton/ pipeline files

## Testing
- Verify pipeline parameter is correctly set
- Ensure pipelines can be triggered with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)