### PR TITLE
feat: update FIPS 140-3 posture for Go native crypto module

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -3,10 +3,12 @@ FROM registry.redhat.io/ubi9/go-toolset:9.8-1783931515@sha256:c6b19c92a8613bcfdf
 ENV CGO_ENABLED=0
 ENV GOFIPS140=v1.0.0
 
+USER root
 WORKDIR /ct_server
 RUN git config --global --add safe.directory /ct_server
 COPY . .
-RUN go build -o ct_server -tags=no_openssl -mod=readonly -trimpath ./trillian/ctfe/ct_server
+RUN go mod edit -godebug=fips140=auto
+RUN go build -o ct_server -tags=no_openssl -trimpath ./trillian/ctfe/ct_server
 
 # Install server
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8201445bebcb5bd4fe23fcc2a76cd5fec029ab401d270926a1563c03b36f0137

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/google/certificate-transparency-go
 
 go 1.26.0
 
-godebug fips140=auto
-
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/fullstorydev/grpcurl v1.9.3

--- a/tls/signature.go
+++ b/tls/signature.go
@@ -18,6 +18,7 @@ import (
 	"crypto"
 	"crypto/dsa" //nolint:staticcheck
 	"crypto/ecdsa"
+	"crypto/fips140"
 	_ "crypto/md5" // For registration side-effect
 	"crypto/rand"
 	"crypto/rsa"
@@ -40,8 +41,14 @@ func generateHash(algo HashAlgorithm, data []byte) ([]byte, crypto.Hash, error) 
 	var hashType crypto.Hash
 	switch algo {
 	case MD5:
+		if fips140.Enabled() {
+			return nil, hashType, fmt.Errorf("MD5 is not permitted in FIPS 140-3 mode")
+		}
 		hashType = crypto.MD5
 	case SHA1:
+		if fips140.Enabled() {
+			return nil, hashType, fmt.Errorf("SHA-1 is not permitted in FIPS 140-3 mode")
+		}
 		hashType = crypto.SHA1
 	case SHA224:
 		hashType = crypto.SHA224

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -19,7 +19,6 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
-	"crypto/fips140"
 	"crypto/rsa"
 	"errors"
 	"fmt"
@@ -154,15 +153,6 @@ func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {
 		if signer, err = keys.NewSigner(ctx, vCfg.PrivKey); err != nil {
 			return nil, fmt.Errorf("failed to load private key: %v", err)
 		}
-
-		// RHTAS FIPS - DO NOT REMOVE
-		// ========================================
-		// Ed25519 uses Curve25519 which is not a NIST-approved curve
-		// and is not permitted under FIPS 140-3.
-		if _, ok := signer.Public().(ed25519.PublicKey); ok && fips140.Enabled() {
-			return nil, errors.New("Ed25519 keys are not supported in FIPS 140-3 mode")
-		}
-		// ========================================
 
 		// If a public key has been configured for a log, check that it is consistent with the private key.
 		if vCfg.PubKey != nil {

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -1150,14 +1150,6 @@ func checkSignature(algo SignatureAlgorithm, signed, signature []byte, publicKey
 		}
 		return
 	case ed25519.PublicKey:
-		// RHTAS FIPS - DO NOT REMOVE
-		// ========================================
-		// Ed25519 uses Curve25519 which is not a NIST-approved curve
-		// and is not permitted under FIPS 140-3.
-		if fips140.Enabled() {
-			return errors.New("x509: Ed25519 signature verification is not supported in FIPS 140-3 mode")
-		}
-		// ========================================
 		if pubKeyAlgo != Ed25519 {
 			return signaturePublicKeyAlgoMismatchError(pubKeyAlgo, pub)
 		}


### PR DESCRIPTION
## Summary
- Remove Ed25519 FIPS blocks — Ed25519 is now approved under FIPS 186-5 in Go's
  native FIPS 140-3 Cryptographic Module (CAVP cert A6650, `GOFIPS140=v1.0.0`)
- Block MD5 and SHA-1 in `tls/signature.go` when FIPS mode is active
- Move `godebug fips140=auto` from `go.mod` into `Dockerfile.rh` via
  `go mod edit`, keeping the repo compatible with upstream Go
- Add `USER root` to Dockerfile build stage for `go.mod` write access