### PR TITLE
Update release-version to 1.5.0

### DIFF
--- a/.tekton/certificate-transparency-go-pull-request.yaml
+++ b/.tekton/certificate-transparency-go-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.rh
   - name: git-url

--- a/.tekton/certificate-transparency-go-push.yaml
+++ b/.tekton/certificate-transparency-go-push.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: dockerfile
     value: Dockerfile.rh
   - name: git-url


### PR DESCRIPTION
## Summary
- Update `release-version` parameter from `1.4.0` to `1.5.0` in all `.tekton` pipeline definitions

## Test plan
- [x] Verify Tekton pipeline definitions are valid YAML
- [x] Confirm `release-version` is set to `1.5.0` in all pipeline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)